### PR TITLE
feat(view-all-items): view all items with pagination in descending order

### DIFF
--- a/src/controllers/items.js
+++ b/src/controllers/items.js
@@ -1,0 +1,28 @@
+const service = require("../services/items")
+
+//get all items with pagination
+const getAllItems = async (req, res, next) => {
+    try {
+        //destructure page and size, if they are empty default to 3 for size and 1 for page
+        const { size = 5, page = 1 } = req.query
+        
+        // extract offset and limit for pagination
+        const limit = parseInt(size) <= 5 ? parseInt(size) : 5 //ensures that maximum size is 5
+        const offset = (parseInt(page) - 1) * limit
+    
+
+        const items = await service.getAll({limit, offset})
+
+        res.json( { 
+            page,
+            items
+        }  )
+    }catch(error){
+        next(error)
+    }
+}
+
+
+module.exports = {
+    getAllItems
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const express = require("express")
 const cors = require("cors")
-const db = require("./config/db.config.js")
+// const db = require("./config/db.config.js")
 
 //routes
 const itemsRouter = require("./routers/items")
@@ -11,16 +11,35 @@ app.use(cors())
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
 
-const port = process.env.PORT || 8080
+//logging every request made to the API
+app.use((req, res, next) => {
+    const { method, path } = req;
+    console.log(
+      `New request to: ${method} ${path} at ${new Date().toISOString()}`
+    );
+    next();
+});
 
 app.use("/api/v1/fashion", itemsRouter)
 
 
 //redirect requests to root to version 1 of the api
 app.get("/", (req, res) => {
-    res.redirect("/api/v1/fashion");
+    const { page, size } = req.query
+
+    // if the request has only page query parameter redirect with only page
+    if(page & !size){
+        res.redirect(`/api/v1/fashion?page=${page}`)
+    //if it has both page and size redirect with both
+    }else if(page && size){
+        res.redirect(`/api/v1/fashion?page=${page}&size=${size}`)
+    }else{
+        res.redirect("/api/v1/fashion")
+    }
+
 });
 
+const port = process.env.PORT || 8080
 app.listen(port, ()=>{
     console.log(`app running on port ${port}`)
 })

--- a/src/routers/items.js
+++ b/src/routers/items.js
@@ -1,6 +1,11 @@
 const express = require("express")
 const router = express.Router()
 
-router.get("/")
+//import handlers from controllers
+const {
+    getAllItems
+} = require("../controllers/items")
+
+router.get("/", getAllItems)
 
 module.exports =  router

--- a/src/services/items.js
+++ b/src/services/items.js
@@ -1,0 +1,13 @@
+const db = require("../config/db.config")
+
+//get all the items in the database
+const getAll = async ({limit, offset}) => {
+    
+        const items = await db.any('SELECT * FROM items ORDER BY id DESC LIMIT $(limit) OFFSET $(offset)', {limit, offset});
+        return items
+}
+
+
+module.exports = {
+    getAll,
+}


### PR DESCRIPTION
###  What does this PR do?
- set up routers file for all routes for getting items

### Description of Task to be completed?
- add controller and service to view all items
- add pagination for the results to view a maximum of 5 items at a time
- fix redirection to account for query parameters
- the items are returned in descending order 

### How should this be manually tested?
- adding query parameters to the endpoint, no query parameters default to page one with 5 items
- query parameters are "page" and  "size"
-  "localhost:8080/?page=2" return page 2 with 5 items
-  "localhost:8080/?size=3" returns page 1 with 3 items
-  "localhost:8080/?page=3&size=4" returns page 3 with 4 items

### Required
- Run ```npm install``` to install all dependencies before starting the server
